### PR TITLE
fix: command result shouldn't be async

### DIFF
--- a/Audacia.Commands.sln
+++ b/Audacia.Commands.sln
@@ -4,6 +4,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EDD28F6C-87BD-436B-92A5-F5A3D3FA6FEB}"
+	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Audacia.Commands", "src\Audacia.Commands\Audacia.Commands.csproj", "{6E927C12-1B09-42C7-AF69-B4AB3F9BBE5D}"
 EndProject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,50 @@
 # Changelog
 
+## 2.0.0 - 2025-06-05
+
+- Modified Validation model `ToCommandResultAsync` to `ToCommandResult` as no need to be async operation.
+- Corrected typos in documentation.
+
 ## 1.1.3 - 2024-11-20
+
 ### Added
+
 - No new functionality added
 
 ### Changed
+
 - No functionality changed
 
 ### Fixed
+
 - Upgraded vulnerable versions ([40e414f](https://github.com/audaciaconsulting/Audacia.Commands/commit/40e414f7cb92706e7185f328bde93771df077c3f))
 
 ## 1.1.2 - 2024-09-05
+
 ### Added
+
 - CHANGELOG.md file added
 
 ### Changed
+
 - README.md updated to include CHANGELOG.md reference
 
 ## 1.1.1 - 2023-08-02
+
 ### Added
+
 - No new functionality added
 
 ### Changed
+
 - Preparation for making library open source
 
 ## 1.0.0 - 2020-04-30
+
 ### Added
+
 - No new functionality added
 
 ### Changed
+
 - Renamed build pipeline to utilise revision

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ if(!model.IsModelNull())
           .MustBeGreaterThan(3);
 }
 
-return await model.ToCommandResult();
+return model.ToCommandResult();
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 A 'command' is generally a Plain Old CLR Object (POCO) that represents some kind of action that needs to be performed (e.g. `AddCustomer`). Each command should implement the `ICommand` interface, which is a marker interface.
 
 In order to execute a command the `ICommandHandler<T>` interface must be implemented, where the generic parameter `T` is the type of the command. For example using the `AddCustomer` example above, the handler implementation would look like this:
+
 ```csharp
 public class AddCustomerHandler : ICommandHandler<AddCustomer>
 {
@@ -35,9 +36,11 @@ Cross-cutting concerns can be addressed using generic handlers. `ExceptionHandli
 Validation can be performed by implementing the `ICommandValidator<T>` interface and injecting this into the handler. Validation is discussed in more depth below.
 
 ## Audacia.Commands.Validation
+
 **NOTE**: This part of the library is intended to make validation commands easier, but you can use it for any class object.
 
 ### Example usage:
+
 ```csharp
 using Audacia.Commands.Validation;
 ...
@@ -54,112 +57,119 @@ if(!model.IsModelNull())
           .MustBeGreaterThan(3);
 }
 
-return await model.ToCommandResultAsync();
+return await model.ToCommandResult();
 ```
 
 ---
 
 ### IValidationModel
+
 A validation model is a collection of validation results for provided class properties and validation logic.
 
 #### Properties
+
 - **AllErrors** `IEnumerable<string>`
-All validation errors regardless of property.
+  All validation errors regardless of property.
 
 - **ModelErrors** `IDictionary<string, IEnumerable<string>>`
-Key value pairs of Property Name and Validation Errors, 
-Any errors against the Model uses a blank string as the Property Name.
+  Key value pairs of Property Name and Validation Errors,
+  Any errors against the Model uses a blank string as the Property Name.
 
 - **IsValid** `bool`
-Is true if there are no errors.
+  Is true if there are no errors.
 
 - **ModelName** `string`
-User friendly model name.
+  User friendly model name.
 
 #### Methods
+
 - **IsModelNull** `bool IsModelNull()`
-Checks if the model is null,
-Adds a validation error when null.
+  Checks if the model is null,
+  Adds a validation error when null.
 
 - **Property** `ValidationProperty Property(Expression<Func<TModel, TProperty>> property, string displayName);`
-Creates a validation property from which you can fluently attach validation extensions.
+  Creates a validation property from which you can fluently attach validation extensions.
 
 - **AddModelError** `void AddModelError(string propertyName, string errorMessage)`
-Adds a validation error for a property.
+  Adds a validation error for a property.
 
-- **ToCommandResultAsync** `Task<CommandResult> ToCommandResultAsync()`
-Appends any validation errors to the command result.
+- **ToCommandResultc** `CommandResult ToCommandResult()`
+  Appends any validation errors to the command result.
 
 ---
 
 ### Validation Property
+
 A validation property is a model to validate a single property.
 
 #### Properties
+
 - **ModelName** `string`
-User friendly model name.
+  User friendly model name.
 
 - **PropertyName** `string`
-Name of the property.
+  Name of the property.
 
 - **DisplayName** `string`
-User friendly property name.
+  User friendly property name.
 
 - **Value** `TProperty`
-Property value.
+  Property value.
 
 #### Methods
+
 - **AddError** `void AddError(string message)`
-Adds a validation error to the property.
+  Adds a validation error to the property.
 
 - **Property** `Property(Expression<Func<TProperty, TChild>> property, string displayName)`
-Creates a child validation property on a property object.
+  Creates a child validation property on a property object.
 
 ---
 
 ### Extensions Methods
 
 - **AlreadyExists** `AlreadyExists(bool exists)`
-Adds a model error explaining the value already exists.
-This only adds a message, you need to provide the logic for if your unique value exists or not.
+  Adds a model error explaining the value already exists.
+  This only adds a message, you need to provide the logic for if your unique value exists or not.
 
 - **IsRequired** `IsRequired()`
-Validates that the property has been filled in.
+  Validates that the property has been filled in.
 
 - **IsRequired** `IsRequired()` (collections only)
-Validates that there is at least one element on a collection.
+  Validates that there is at least one element on a collection.
 
 - **HasMaxLength** `HasMaxLength(int length)` (strings only)
-Validates that the property is not longer than the max length.
+  Validates that the property is not longer than the max length.
 
 - **HasMaxLength** `HasMaxLength(int length)` (collections only)
-Validates that the collection is not longer than the max length.
+  Validates that the collection is not longer than the max length.
 
 - **HasMinLength** `HasMinLength(int length)` (strings only)
-Validates that the property is not shorter than the min length.
+  Validates that the property is not shorter than the min length.
 
 - **HasMinLength** `HasMinLength(int length)` (collections only)
-Validates that the collection is not shorter than the min length.
+  Validates that the collection is not shorter than the min length.
 
 - **MatchesPattern** `MatchesPattern(string pattern, params string[] conditions)` (strings only)
-Validates that the property matches a given regex pattern.
+  Validates that the property matches a given regex pattern.
 
 - **MustBeAValidId** `MustBeAValidId()` (int?)
-Validates that the Id is not null or less than zero.
+  Validates that the Id is not null or less than zero.
 
 - **MustBeGreaterThan** `MustBeGreaterThan(TProperty number)`
-Validates that the property is greater than the given value. (IComparable)
+  Validates that the property is greater than the given value. (IComparable)
 
 - **MustBeGreaterThanOrEqualTo** `MustBeGreaterThanOrEqualTo(TProperty number)` (IComparable)
-Validates that the property is greater than or equal to the given value.
+  Validates that the property is greater than or equal to the given value.
 
 - **MustBeLessThan** `MustBeLessThan(TProperty number)` (IComparable)
-Validates that the property is less than the given value.
+  Validates that the property is less than the given value.
 
 - **MustBeLessThanOrEqualTo** `MustBeLessThanOrEqualTo(TProperty number)` (IComparable)
-Validates that the property is less than or equal to the given value.
+  Validates that the property is less than or equal to the given value.
 
 # Change History
+
 The `Audacia.Commands` repository change history can be found in this [changelog](./CHANGELOG.md)
 
 # Contributing

--- a/src/Audacia.Commands/Audacia.Commands.csproj
+++ b/src/Audacia.Commands/Audacia.Commands.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.1.3</Version>
+    <Version>2.0.0</Version>
     <Authors>Audacia</Authors>
     <Company>Audacia</Company>
     <Copyright>Copyright Audacia $([System.DateTime]::UtcNow.Year)</Copyright>

--- a/src/Audacia.Commands/Validation/IValidationModel.cs
+++ b/src/Audacia.Commands/Validation/IValidationModel.cs
@@ -22,12 +22,12 @@ namespace Audacia.Commands.Validation
         IEnumerable<string> AllErrors { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not there are any errors.
+        /// Gets a value indicating whether there are any errors.
         /// </summary>
         bool IsValid { get; }
         
         /// <summary>
-        /// Gets a user friendly model name.
+        /// Gets a user-friendly model name.
         /// </summary>
         string ModelName { get; }
 
@@ -49,7 +49,7 @@ namespace Audacia.Commands.Validation
         /// Appends any validation errors to the command result.
         /// </summary>
         /// <returns>A <see cref="CommandResult"/>.</returns>
-        Task<CommandResult> ToCommandResultAsync();
+        CommandResult ToCommandResult();
     }
 
     /// <summary>
@@ -62,8 +62,8 @@ namespace Audacia.Commands.Validation
         /// Creates a validation property.
         /// </summary>
         /// <typeparam name="TProperty">Type of the member being validated.</typeparam>
-        /// <param name="property">Expresssion referencing the member being validated.</param>
-        /// <param name="displayName">User friendly member name.</param>
+        /// <param name="property">Expression referencing the member being validated.</param>
+        /// <param name="displayName">User-friendly member name.</param>
         /// <returns>A validation property.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Name best represents the purpose of the method.")]
         ValidationProperty<TProperty> Property<TProperty>(Expression<Func<TModel, TProperty>> property, string? displayName = null);

--- a/src/Audacia.Commands/Validation/ValidationModel.cs
+++ b/src/Audacia.Commands/Validation/ValidationModel.cs
@@ -14,6 +14,7 @@ namespace Audacia.Commands.Validation
     public class ValidationModel<TModel> : ValidationBase, IValidationModel<TModel> where TModel : class
     {
         private readonly TModel _model;
+
         private readonly IDictionary<string, HashSet<string>> _errors;
 
         /// <summary>
@@ -21,9 +22,11 @@ namespace Audacia.Commands.Validation
         /// </summary>
         /// <param name="model">The <typeparamref name="TModel"/> instance to validate.</param>
         /// <param name="modelName">The name of the model.</param>
-        public ValidationModel(TModel model, string modelName)
+        public ValidationModel(
+            TModel model,
+            string modelName)
         {
-            ModelName = string.IsNullOrWhiteSpace(modelName) 
+            ModelName = string.IsNullOrWhiteSpace(modelName)
                 ? typeof(TModel).Name.SplitCamelCase()
                 : modelName;
             _model = model;
@@ -37,13 +40,16 @@ namespace Audacia.Commands.Validation
         public bool IsValid => !_errors.Any();
 
         /// <inheritdoc />
-        public IDictionary<string, IEnumerable<string>> ModelErrors => _errors as IDictionary<string, IEnumerable<string>> ?? new Dictionary<string, IEnumerable<string>>();
+        public IDictionary<string, IEnumerable<string>> ModelErrors =>
+            _errors as IDictionary<string, IEnumerable<string>> ?? new Dictionary<string, IEnumerable<string>>();
 
         /// <inheritdoc />
         public IEnumerable<string> AllErrors => _errors.SelectMany(kvp => kvp.Value).ToArray();
 
         /// <inheritdoc />
-        public void AddModelError(string propertyName, string errorMessage)
+        public void AddModelError(
+            string propertyName,
+            string errorMessage)
         {
             if (propertyName == null)
             {
@@ -77,22 +83,24 @@ namespace Audacia.Commands.Validation
 
             return false;
         }
-        
+
         /// <inheritdoc />
-        public ValidationProperty<TProperty> Property<TProperty>(Expression<Func<TModel, TProperty>> property, string? displayName = null)
-        { 
+        public ValidationProperty<TProperty> Property<TProperty>(
+            Expression<Func<TModel, TProperty>> property,
+            string? displayName = null)
+        {
             if (property == null) throw new ArgumentNullException(nameof(property));
 
             var propertyName = GetNameForProperty(property);
-            var value = property.Compile()(_model); 
+            var value = property.Compile()(_model);
 
             return new ValidationProperty<TProperty>(this, propertyName, displayName, value);
         }
 
         /// <inheritdoc />
-        public Task<CommandResult> ToCommandResultAsync()
+        public CommandResult ToCommandResult()
         {
-            return Task.FromResult(new CommandResult(IsValid, AllErrors));
+            return new CommandResult(IsValid, AllErrors);
         }
     }
 }

--- a/src/Audacia.Commands/Validation/ValidationProperty.cs
+++ b/src/Audacia.Commands/Validation/ValidationProperty.cs
@@ -19,14 +19,18 @@ namespace Audacia.Commands.Validation
         /// <param name="propertyName">The name of the property being validated.</param>
         /// <param name="displayName">The user friendly name of the property.</param>
         /// <param name="value">The property value.</param>
-        public ValidationProperty(IValidationModel validationModel, string propertyName, string? displayName, TProperty value)
+        public ValidationProperty(
+            IValidationModel validationModel,
+            string propertyName,
+            string? displayName,
+            TProperty value)
         {
             _validationModel = validationModel;
             PropertyName = propertyName;
             DisplayName = displayName ?? propertyName.SplitCamelCase();
             Value = value;
         }
-        
+
         /// <summary>
         /// Adds a validation error to the property.
         /// </summary>
@@ -34,7 +38,7 @@ namespace Audacia.Commands.Validation
         public void AddError(string message) => _validationModel.AddModelError(PropertyName, message);
 
         /// <summary>
-        /// Gets a user friendly model name.
+        /// Gets a user-friendly model name.
         /// </summary>
         public string ModelName => _validationModel.ModelName;
 
@@ -44,7 +48,7 @@ namespace Audacia.Commands.Validation
         public string PropertyName { get; }
 
         /// <summary>
-        /// Gets a user friendly property name.
+        /// Gets a user-friendly property name.
         /// </summary>
         public string DisplayName { get; }
 
@@ -52,17 +56,19 @@ namespace Audacia.Commands.Validation
         /// Gets the property value.
         /// </summary>
         public TProperty Value { get; }
-        
+
         /// <summary>
         /// Creates a child validation property on a property object.
         /// </summary>
         /// <typeparam name="TChild">Type of the member being validated.</typeparam>
-        /// <param name="property">Expresssion referencing the member being validated.</param>
-        /// <param name="displayName">User friendly member name.</param>
+        /// <param name="property">Expression referencing the member being validated.</param>
+        /// <param name="displayName">User-friendly member name.</param>
         /// <returns>A validation property.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="property"/> is <see langword="null"/>.</exception>
-        public ValidationProperty<TChild> Property<TChild>(Expression<Func<TProperty, TChild>> property, string? displayName = null)
-        { 
+        public ValidationProperty<TChild> Property<TChild>(
+            Expression<Func<TProperty, TChild>> property,
+            string? displayName = null)
+        {
             if (property == null) throw new ArgumentNullException(nameof(property));
 
             var propertyName = GetNameForProperty(property);


### PR DESCRIPTION
* bump to v2.0.0
* `ToCommandResultAsync` doesn't need to be async
* typos in documentation

### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG


### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ❌ New or modified code not covered by tests

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Dependency licenses
- ✔ Licenses of new/upgraded dependencies checked, with no copyleft dependencies introduced

### Work item linked
- ❎ No work item exists and none is needed